### PR TITLE
SST flash support

### DIFF
--- a/XTIDE_Universal_BIOS_Configurator_v2/Inc/Variables.inc
+++ b/XTIDE_Universal_BIOS_Configurator_v2/Inc/Variables.inc
@@ -28,10 +28,8 @@ EEPROM_POLLING_TIMEOUT_TICKS			EQU		3		; 1 tick = 54.9 ms
 XTIDE_SIGNATURE_LENGTH					EQU		6		; XTIDE Universal BIOS signature string length (must be even)
 NUMBER_OF_EEPROM_TYPES					EQU		5
 MAX_EEPROM_SIZE_IN_BYTES				EQU		65536
-SST_POLLING_TIMEOUT_TICKS				EQU		4		; 219.6 ms, about 9x datasheet max time for sector erase and 
-														; 1000's of times longer than byte write time.
-SST_PAGE_SHIFT							EQU		12		; Minimum we can erase is a 4K sector.
-SST_PAGE_SIZE							EQU		(1 << SST_PAGE_SHIFT)	
+SST_PAGE_SIZE_SHIFT						EQU		12		; Minimum we can erase is a 4K sector.
+SST_PAGE_SIZE							EQU		(1 << SST_PAGE_SIZE_SHIFT)	
 
 ; Program global variables
 struc CFGVARS

--- a/XTIDE_Universal_BIOS_Configurator_v2/Inc/Variables.inc
+++ b/XTIDE_Universal_BIOS_Configurator_v2/Inc/Variables.inc
@@ -21,14 +21,17 @@
 %define VARIABLES_INC
 
 ; Equates and defines
-BOOT_MENU_DEFAULT_TIMEOUT			EQU		(TICKS_PER_MINUTE / 2)
-MAX_ALLOWED_IDE_CONTROLLERS			EQU		4	; Maximum number of IDE controllers
-MAX_LITE_MODE_CONTROLLERS			EQU		2
-EEPROM_POLLING_TIMEOUT_TICKS		EQU		3	; 1 tick = 54.9 ms
-XTIDE_SIGNATURE_LENGTH				EQU		6	; XTIDE Universal BIOS signature string length (must be even)
-NUMBER_OF_EEPROM_TYPES				EQU		5
-MAX_EEPROM_SIZE_IN_BYTES			EQU		65536
-
+BOOT_MENU_DEFAULT_TIMEOUT				EQU		(TICKS_PER_MINUTE / 2)
+MAX_ALLOWED_IDE_CONTROLLERS				EQU		4		; Maximum number of IDE controllers
+MAX_LITE_MODE_CONTROLLERS				EQU		2
+EEPROM_POLLING_TIMEOUT_TICKS			EQU		3		; 1 tick = 54.9 ms
+XTIDE_SIGNATURE_LENGTH					EQU		6		; XTIDE Universal BIOS signature string length (must be even)
+NUMBER_OF_EEPROM_TYPES					EQU		5
+MAX_EEPROM_SIZE_IN_BYTES				EQU		65536
+SST_POLLING_TIMEOUT_TICKS				EQU		4		; 219.6 ms, about 9x datasheet max time for sector erase and 
+														; 1000's of times longer than byte write time.
+SST_PAGE_SHIFT							EQU		12		; Minimum we can erase is a 4K sector.
+SST_PAGE_SIZE							EQU		(1 << SST_PAGE_SHIFT)	
 
 ; Program global variables
 struc CFGVARS
@@ -95,11 +98,8 @@ struc FLASHVARS
 	.bEepromSdpCommand			resb	1
 	.bEepromType				resb	1
 
-	.wTimeoutCalibrationLow		resb	2	; Used by SST flashing.
-	.wTimeoutCalibrationHigh	resb	2
-
 	.wProgressUpdateParam		resb	2
-	.wTimeoutCounter			resb	2
+	.wTimeoutCounter			resb	2	; On SSI, this is timeout cal
 	.wLastOffsetWritten			resb	2
 	.bLastByteWritten			resb	1
 	.flashResult				resb	1

--- a/XTIDE_Universal_BIOS_Configurator_v2/Inc/Variables.inc
+++ b/XTIDE_Universal_BIOS_Configurator_v2/Inc/Variables.inc
@@ -105,6 +105,7 @@ endstruc
 ; Flashing results
 struc FLASH_RESULT
 	.success					resb	2
+	.DeviceNotDetected			resb	2
 	.PollingTimeoutError		resb	2
 	.DataVerifyError			resb	2
 endstruc

--- a/XTIDE_Universal_BIOS_Configurator_v2/Inc/Variables.inc
+++ b/XTIDE_Universal_BIOS_Configurator_v2/Inc/Variables.inc
@@ -56,6 +56,7 @@ struc EEPROM_TYPE
 	.2864_8kiB_MOD		resb	2	; Reversed A0 and A3 address lines
 	.28256_32kiB		resb	2
 	.28512_64kiB		resb	2
+	.SST_39SF			resb	2
 endstruc
 
 ; Software Data Protection commands

--- a/XTIDE_Universal_BIOS_Configurator_v2/Inc/Variables.inc
+++ b/XTIDE_Universal_BIOS_Configurator_v2/Inc/Variables.inc
@@ -95,6 +95,9 @@ struc FLASHVARS
 	.bEepromSdpCommand			resb	1
 	.bEepromType				resb	1
 
+	.wTimeoutCalibrationLow		resb	2	; Used by SST flashing.
+	.wTimeoutCalibrationHigh	resb	2
+
 	.wProgressUpdateParam		resb	2
 	.wTimeoutCounter			resb	2
 	.wLastOffsetWritten			resb	2

--- a/XTIDE_Universal_BIOS_Configurator_v2/Src/EEPROM.asm
+++ b/XTIDE_Universal_BIOS_Configurator_v2/Src/EEPROM.asm
@@ -27,6 +27,9 @@ g_rgwEepromTypeToSizeInWords:
 	dw		(8<<10) / 2		; EEPROM_TYPE.2864_8kiB_MOD
 	dw		(32<<10) / 2
 	dw		(64<<10) / 2
+	dw		(32<<10) / 2	; EEPROM_TYPE.SST_39SF
+							; Actual size of flash will be larger than 32K,
+							; however most (all?) XUB devices map a 32K window.
 
 g_rgwEepromPageToSizeInBytes:
 	dw		1				; EEPROM_PAGE.1_byte

--- a/XTIDE_Universal_BIOS_Configurator_v2/Src/Flash.asm
+++ b/XTIDE_Universal_BIOS_Configurator_v2/Src/Flash.asm
@@ -122,18 +122,21 @@ ALIGN WORD_ALIGN
 	dw		DoNotWriteAnySdpCommand					; EEPROM_TYPE.2864_8kiB_MOD
 	dw		DoNotWriteAnySdpCommand					; EEPROM_TYPE.28256_32kiB
 	dw		DoNotWriteAnySdpCommand					; EEPROM_TYPE.28512_64kiB
+	dw		DoNotWriteAnySdpCommand					; EEPROM_TYPE.SST_39SF
 .rgfnEnableSdpAndFlash:		; SDP_COMMAND.enable
 	dw		WriteSdpEnableCommandFor2816			; EEPROM_TYPE.2816_2kiB
 	dw		WriteSdpEnableCommandFor2864			; EEPROM_TYPE.2864_8kiB
 	dw		WriteSdpEnableCommandFor2864mod			; EEPROM_TYPE.2864_8kiB_MOD
 	dw		WriteSdpEnableCommandFor28256or28512	; EEPROM_TYPE.28256_32kiB
 	dw		WriteSdpEnableCommandFor28256or28512	; EEPROM_TYPE.28512_64kiB
+	dw		DoNotWriteAnySdpCommand					; EEPROM_TYPE.SST_39SF
 .rgfnDisableSdpAndFlash:	; SDP_COMMAND.disable
 	dw		WriteSdpDisableCommandFor2816			; EEPROM_TYPE.2816_2kiB
 	dw		WriteSdpDisableCommandFor2864			; EEPROM_TYPE.2864_8kiB
 	dw		WriteSdpDisableCommandFor2864mod		; EEPROM_TYPE.2864_8kiB_MOD
 	dw		WriteSdpDisableCommandFor28256or28512	; EEPROM_TYPE.28256_32kiB
 	dw		WriteSdpDisableCommandFor28256or28512	; EEPROM_TYPE.28512_64kiB
+	dw		DoNotWriteAnySdpCommand					; EEPROM_TYPE.SST_39SF
 
 
 ;--------------------------------------------------------------------

--- a/XTIDE_Universal_BIOS_Configurator_v2/Src/FlashSST.asm
+++ b/XTIDE_Universal_BIOS_Configurator_v2/Src/FlashSST.asm
@@ -51,10 +51,10 @@ ALIGN JUMP_ALIGN
 	pop		cx
 	pop		di
 	pop		si
-	jnz		.FlashThisPage
+	jnz		SHORT .FlashThisPage
 	add		si, bx
 	add		di, bx
-	jmp		.ContinueLoop
+	jmp		SHORT .ContinueLoop
 
 .FlashThisPage:
 	call	EraseSstPage
@@ -210,10 +210,10 @@ EraseSstPage:
 	mov		cx, [bp+FLASHVARS.wTimeoutCounter]
 .TimeoutInnerLoop:
 	cmp		BYTE [es:di], 0FFh		; Will return 0FFh when erase complete.
-	jz		.Exit
+	jz		SHORT .Exit
 	loop	.TimeoutInnerLoop
 	dec		ax
-	jnz		.TimeoutOuterLoop
+	jnz		SHORT .TimeoutOuterLoop
 	stc								; Timed out.
 .Exit:
 	pop		cx

--- a/XTIDE_Universal_BIOS_Configurator_v2/Src/FlashSST.asm
+++ b/XTIDE_Universal_BIOS_Configurator_v2/Src/FlashSST.asm
@@ -38,6 +38,9 @@ FlashSst_WithFlashvarsInDSBX:
 	mov		cx, [bp+FLASHVARS.wPagesToFlash]
 	lds		si, [bp+FLASHVARS.fpNextSourcePage]
 	les		di, [bp+FLASHVARS.fpNextDestinationPage]
+%ifdef CLD_NEEDED
+	cld
+%endif
 
 ALIGN JUMP_ALIGN
 .NextPage:

--- a/XTIDE_Universal_BIOS_Configurator_v2/Src/FlashSST.asm
+++ b/XTIDE_Universal_BIOS_Configurator_v2/Src/FlashSST.asm
@@ -1,0 +1,51 @@
+; Project name	:	XTIDE Universal BIOS Configurator v2
+; Description	:	Functions for flashing SST flash devices.
+
+;
+; Created by Jayeson Lee-Steere
+; Hereby placed into the public domain.
+;
+
+; Section containing code
+SECTION .text
+
+;--------------------------------------------------------------------
+; Flash_SstWithFlashvarsInDSSI
+;	Parameters:
+;		DS:SI:	Ptr to FLASHVARS
+;	Returns:
+;		FLASHVARS.flashResult
+;	Corrupts registers:
+;		All, including segments
+;--------------------------------------------------------------------
+ALIGN JUMP_ALIGN
+Flash_SstWithFlashvarsInDSSI:
+	mov		bp, si									; Flashvars now in SS:BP
+	mov		cx, 1 ; TODO
+ALIGN JUMP_ALIGN
+.FlashNextPage:
+
+; TODO:
+
+	loop	.FlashNextPage
+%ifndef CHECK_FOR_UNUSED_ENTRYPOINTS
+%if FLASH_RESULT.success = 0	; Just in case this should ever change
+	mov		[bp+FLASHVARS.flashResult], cl
+%else
+	mov		BYTE [bp+FLASHVARS.flashResult], FLASH_RESULT.success
+%endif
+%endif
+	ret
+
+.DeviceDetectionError:
+	mov		BYTE [bp+FLASHVARS.flashResult], FLASH_RESULT.DeviceNotDetected
+	ret
+.PollingError:
+	mov		BYTE [bp+FLASHVARS.flashResult], FLASH_RESULT.PollingTimeoutError
+	ret
+.DataVerifyError:
+	mov		BYTE [bp+FLASHVARS.flashResult], FLASH_RESULT.DataVerifyError
+	ret
+
+
+

--- a/XTIDE_Universal_BIOS_Configurator_v2/Src/FlashSST.asm
+++ b/XTIDE_Universal_BIOS_Configurator_v2/Src/FlashSST.asm
@@ -10,24 +10,46 @@
 SECTION .text
 
 ;--------------------------------------------------------------------
-; Flash_SstWithFlashvarsInDSSI
+; FlashSst_WithFlashvarsInDSSI
 ;	Parameters:
-;		DS:SI:	Ptr to FLASHVARS
+;		DS:BX:	Ptr to FLASHVARS
 ;	Returns:
-;		FLASHVARS.flashResult
+;		Updated FLASHVARS in DS:BX
 ;	Corrupts registers:
-;		All, including segments
+;		AX, DX, DI
 ;--------------------------------------------------------------------
 ALIGN JUMP_ALIGN
-Flash_SstWithFlashvarsInDSSI:
-	mov		bp, si									; Flashvars now in SS:BP
-	mov		cx, 1 ; TODO
+FlashSst_WithFlashvarsInDSBX:
+	push	ds
+	push	es
+	push	bx
+	push	cx
+	push	si
+	push	bp
+	mov		bp, bx									; Flashvars now in SS:BP
+
+	mov		BYTE [bp+FLASHVARS.flashResult], FLASH_RESULT.DeviceNotDetected
+	call	DetectSstDevice
+	jc		SHORT .ExitOnError
+
+	call	CalibrateSstTimeout
+	
+	mov		BYTE [bp+FLASHVARS.flashResult], FLASH_RESULT.PollingTimeoutError
+	mov		cx, [bp+FLASHVARS.wPagesToFlash]
+	; TODO: load DS:SI and ES:DI with source/dest.
 ALIGN JUMP_ALIGN
 .FlashNextPage:
-
-; TODO:
-
+	call	EraseSstPage
+	jc		SHORT .ExitOnError
+	call	WriteSstPage
+	jc		SHORT .ExitOnError
 	loop	.FlashNextPage
+
+	; TODO: load DS:SI and ES:DI with source/dest.
+
+	; TODO: Verify results match.
+	mov		BYTE [bp+FLASHVARS.flashResult], FLASH_RESULT.DataVerifyError
+
 %ifndef CHECK_FOR_UNUSED_ENTRYPOINTS
 %if FLASH_RESULT.success = 0	; Just in case this should ever change
 	mov		[bp+FLASHVARS.flashResult], cl
@@ -35,17 +57,146 @@ ALIGN JUMP_ALIGN
 	mov		BYTE [bp+FLASHVARS.flashResult], FLASH_RESULT.success
 %endif
 %endif
+ALIGN JUMP_ALIGN
+.ExitOnError:
+	pop		bp
+	pop		si
+	pop		cx
+	pop		bx
+	pop		es
+	pop		ds
 	ret
 
-.DeviceDetectionError:
-	mov		BYTE [bp+FLASHVARS.flashResult], FLASH_RESULT.DeviceNotDetected
-	ret
-.PollingError:
-	mov		BYTE [bp+FLASHVARS.flashResult], FLASH_RESULT.PollingTimeoutError
-	ret
-.DataVerifyError:
-	mov		BYTE [bp+FLASHVARS.flashResult], FLASH_RESULT.DataVerifyError
+;--------------------------------------------------------------------
+; GetDestinationFarPtr
+;	Parameters:
+;		SS:BP:	Ptr to FLASHVARS
+;	Returns:
+;		ES:DI:	Ptr to destination location
+;	Corrupts registers:
+;		Nothing
+;--------------------------------------------------------------------
+ALIGN JUMP_ALIGN
+GetDestinationFarPtr:
+	mov		di, [bp+FLASHVARS.fpNextDestinationPage+2]
+	mov		es, di
+	mov		di, [bp+FLASHVARS.fpNextDestinationPage]
 	ret
 
+;--------------------------------------------------------------------
+; DetectSstDevice
+;	Parameters:
+;		SS:BP:	Ptr to FLASHVARS
+;	Returns:
+;		CF:	Clear if supported SST device found
+;			Set if supported SST device not found
+;	Corrupts registers:
+;		AX, DI, ES
+;--------------------------------------------------------------------
+ALIGN JUMP_ALIGN
+DetectSstDevice:
+	call	GetDestinationFarPtr
 
+	cli
+	mov		BYTE [es:05555h], 0AAh	; Enter software ID sequence.
+	mov		BYTE [es:02AAAh], 055h
+	mov		BYTE [es:05555h], 090h
+	mov		al, [es:di]				; Extra reads to be sure device
+	mov		al, [es:di]				; has time to respond.
+	mov		al, [es:di]
+	mov		ah, [es:di]				; Vendor ID in AH.
+	mov		al, [es:di + 1]			; Device ID in AL.
+	mov		BYTE [es:05555h], 0F0h	; Exit software ID.
+	sti
+
+	cmp		al, 0B4h
+	jb		SHORT .NotValidDevice
+	cmp		al, 0B7h
+	ja		SHORT .NotValidDevice
+	cmp		ah, 0BFh
+	jne		SHORT .NotValidDevice
+	ret
+
+.NotValidDevice:
+	stc
+	ret
+	
+;--------------------------------------------------------------------
+; CalibrateSstTimeout
+;	Parameters:
+;		SS:BP:	Ptr to FLASHVARS
+;	Returns:
+;		FLASHVARS.wTimeoutCounter
+;	Corrupts registers:
+;		AX, BX, CX, SI, DI, DS, ES
+;--------------------------------------------------------------------
+ALIGN JUMP_ALIGN
+CalibrateSstTimeout:
+	LOAD_BDA_SEGMENT_TO	ds, ax
+	call	GetDestinationFarPtr
+	xor		cx, cx
+	mov		si, cx
+	mov		di, cx
+	mov		al, [es:di]
+	not		al							; Forces poll to fail.
+
+	mov		bx, [BDA.dwTimerTicks]		; Read low word only.
+	inc		bx
+.WaitForFirstIncrement:
+	cmp		bx, [BDA.dwTimerTicks]
+	jnz		SHORT .WaitForFirstIncrement
+
+	inc		bx
+
+.WaitForSecondIncrement:
+	inc		ch							; cx now 0x0100
+.PollLoop:								; Identical to poll loop used 
+	cmp		[es:di], al					; during programming
+	jz		SHORT .PollComplete			; Will never branch in this case
+	loop	.PollLoop
+.PollComplete:
+	add		si, 1						; number of poll loops completed
+	jc		SHORT .countOverflow
+	cmp		bx, [BDA.dwTimerTicks]
+	jnz		SHORT .WaitForSecondIncrement
+
+.CalComplete:
+	; SI ~= number of polling loops in 215us.
+	mov		[bp+FLASHVARS.wTimeoutCounter], si
+	ret
+		
+.countOverflow:
+	; Clamp on overflow, although it should not be possible on
+	; real hardware. In principle SI could overflow on a very
+	; fast CPU. However the SST device is on a slow bus. Even
+	; running at the min read cycle time of fastest version of
+	; the device, SI can not overflow.
+	dec		si
+	jmp		SHORT .CalComplete
+
+;--------------------------------------------------------------------
+; EraseSstPage
+;	Parameters:
+;		TODO
+;	Returns:
+;		TODO
+;	Corrupts registers:
+;		TODO
+;--------------------------------------------------------------------
+ALIGN JUMP_ALIGN
+EraseSstPage:
+	ret
+
+;--------------------------------------------------------------------
+; EraseSstPage
+;	Parameters:
+;		TODO
+;	Returns:
+;		TODO
+;	Corrupts registers:
+;		TODO
+;--------------------------------------------------------------------
+ALIGN JUMP_ALIGN
+WriteSstPage:
+	ret
 

--- a/XTIDE_Universal_BIOS_Configurator_v2/Src/Main.asm
+++ b/XTIDE_Universal_BIOS_Configurator_v2/Src/Main.asm
@@ -55,6 +55,7 @@ Start:
 %include "Dialogs.asm"
 %include "EEPROM.asm"
 %include "Flash.asm"
+%include "FlashSST.asm"
 %include "IdeAutodetect.asm"
 %include "MenuEvents.asm"
 %include "Menuitem.asm"

--- a/XTIDE_Universal_BIOS_Configurator_v2/Src/Menupages/FlashMenu.asm
+++ b/XTIDE_Universal_BIOS_Configurator_v2/Src/Menupages/FlashMenu.asm
@@ -294,7 +294,7 @@ StartFlashing:
 ;--------------------------------------------------------------------
 ALIGN JUMP_ALIGN
 .MakeSureThatImageFitsInEeprom:
-	call	.GetSelectedEepromSizeInWordsToAX
+	call	Buffers_GetSelectedEepromSizeInWordsToAX
 	cmp		ax, [cs:g_cfgVars+CFGVARS.wImageSizeInWords]
 	jae		SHORT .ImageFitsInSelectedEeprom
 	mov		dx, g_szErrEepromTooSmall
@@ -396,7 +396,7 @@ ALIGN JUMP_ALIGN
 ;--------------------------------------------------------------------
 ALIGN JUMP_ALIGN
 .GetNumberOfPagesToFlashToAX:
-	call	.GetSelectedEepromSizeInWordsToAX
+	call	Buffers_GetSelectedEepromSizeInWordsToAX
 	xor		dx, dx
 	eSHL_IM	ax, 1		; Size in bytes to...
 	eRCL_IM	dx, 1		; ...DX:AX
@@ -406,22 +406,6 @@ ALIGN JUMP_ALIGN
 	div		WORD [si+FLASHVARS.wEepromPageSize]
 .PreventDivideException:
 	ret
-
-;--------------------------------------------------------------------
-; .GetSelectedEepromSizeInWordsToAX
-;	Parameters:
-;		Nothing
-;	Returns:
-;		AX:		Selected EEPROM size in WORDs
-;	Corrupts registers:
-;		BX
-;--------------------------------------------------------------------
-ALIGN JUMP_ALIGN
-.GetSelectedEepromSizeInWordsToAX:
-	eMOVZX	bx, [cs:g_cfgVars+CFGVARS.bEepromType]
-	mov		ax, [cs:bx+g_rgwEepromTypeToSizeInWords]
-	ret
-
 
 ;--------------------------------------------------------------------
 ; .DisplayFlashingResultsFromFlashvarsInDSBX

--- a/XTIDE_Universal_BIOS_Configurator_v2/Src/Menupages/FlashMenu.asm
+++ b/XTIDE_Universal_BIOS_Configurator_v2/Src/Menupages/FlashMenu.asm
@@ -280,7 +280,7 @@ StartFlashing:
 	ret
 
 .FlashWithoutProgressBar:
-;	call	Flash_SstWithFlashvarsInDSSI	; SST devices complete flashing and/or
+	call	Flash_SstWithFlashvarsInDSSI	; SST devices complete flashing and/or
 	jmp		SHORT .FlashComplete			; timeout in well under 1 second. 
 
 ;--------------------------------------------------------------------

--- a/XTIDE_Universal_BIOS_Configurator_v2/Src/Menupages/FlashMenu.asm
+++ b/XTIDE_Universal_BIOS_Configurator_v2/Src/Menupages/FlashMenu.asm
@@ -280,8 +280,8 @@ StartFlashing:
 	ret
 
 .FlashWithoutProgressBar:
-	call	Flash_SstWithFlashvarsInDSSI	; SST devices complete flashing and/or
-	jmp		SHORT .FlashComplete			; timeout in well under 1 second. 
+	call	FlashSst_WithFlashvarsInDSBX	; SST devices with either complete flashing
+	jmp		SHORT .FlashComplete			; or timeout within 1 second. 
 
 ;--------------------------------------------------------------------
 ; .MakeSureThatImageFitsInEeprom
@@ -372,8 +372,13 @@ ALIGN JUMP_ALIGN
 	mov		al, [cs:g_cfgVars+CFGVARS.bSdpCommand]
 	mov		[si+FLASHVARS.bEepromSdpCommand], al
 
+	mov		ax, SST_PAGE_SIZE
+	cmp		WORD [g_cfgVars+CFGVARS.bEepromType], EEPROM_TYPE.SST_39SF
+	jz		SHORT .UseSstPageSize
+
 	eMOVZX	bx, [cs:g_cfgVars+CFGVARS.bEepromPage]
 	mov		ax, [cs:bx+g_rgwEepromPageToSizeInBytes]
+.UseSstPageSize:
 	mov		[si+FLASHVARS.wEepromPageSize], ax
 
 	call	.GetNumberOfPagesToFlashToAX

--- a/XTIDE_Universal_BIOS_Configurator_v2/Src/Menupages/FlashMenu.asm
+++ b/XTIDE_Universal_BIOS_Configurator_v2/Src/Menupages/FlashMenu.asm
@@ -279,9 +279,9 @@ StartFlashing:
 .InvalidFlashingParameters:
 	ret
 
-.FlashWithoutProgressBar:
-	call	FlashSst_WithFlashvarsInDSBX	; SST devices with either complete flashing
-	jmp		SHORT .FlashComplete			; or timeout within 1 second. 
+.FlashWithoutProgressBar:					; Worst case. SST devices will
+	call	FlashSst_WithFlashvarsInDSBX	; either complete flashing
+	jmp		SHORT .FlashComplete			; or timeout within 2 seconds. 
 
 ;--------------------------------------------------------------------
 ; .MakeSureThatImageFitsInEeprom

--- a/XTIDE_Universal_BIOS_Configurator_v2/Src/Strings.asm
+++ b/XTIDE_Universal_BIOS_Configurator_v2/Src/Strings.asm
@@ -555,12 +555,14 @@ g_szMultichoiceEepromType:		db	"2816 (2 kiB)",LF
 								db	"2864 (8 kiB)",LF
 								db	"2864 mod (8 kiB)",LF
 								db	"28256 (32 kiB)",LF
-								db	"28512 (64 kiB)",NULL
+								db	"28512 (64 kiB)",LF
+								db	"SST39SFxxx flash",NULL
 g_szValueFlash2816:				db	"2816",NULL
 g_szValueFlash2864:				db	"2864",NULL
 g_szValueFlash2864Mod:			db	"2864mod",NULL
 g_szValueFlash28256:			db	"28256",NULL
 g_szValueFlash28512:			db	"28512",NULL
+g_szValueFlashSST39SF:			db	"SST39SFx",NULL
 
 g_szMultichoiceSdpCommand:		db	"None",LF
 								db	"Enable",LF

--- a/XTIDE_Universal_BIOS_Configurator_v2/Src/Strings.asm
+++ b/XTIDE_Universal_BIOS_Configurator_v2/Src/Strings.asm
@@ -52,15 +52,17 @@ g_szErrorDialog:		db	"Error!",NULL
 g_szGenericDialogInfo:	db	"Press ENTER or ESC to close dialog.",NULL
 
 ; Flashing related strings
-g_szFlashTitle:			db	"Flashing EEPROM, please wait.",NULL
-g_szErrEepromTooSmall:	db	"Image is too large for selected EEPROM type!",NULL
-g_szErrEepromPolling:	db	"Timeout when polling EEPROM.",LF
-						db	"EEPROM was not flashed properly!",NULL
-g_szErrEepromVerify:	db	"EEPROM did not return the same byte that was written.",LF
-						db	"EEPROM was not flashed properly!",NULL
-g_szPCFlashSuccessful:	db	"EEPROM was written successfully.",LF
-						db	"Press any key to reboot.",NULL
-g_szForeignFlash:		db	"EEPROM was written successfully.",NULL
+g_szFlashTitle:				db	"Flashing EEPROM, please wait.",NULL
+g_szErrEepromTooSmall:		db	"Image is too large for selected EEPROM type!",NULL
+g_szErrAddrNot32KAligned:	db	"The selected EEPROM type requires the address be 32 "
+							db	"kiB aligned (C800, D000, D800, E000, etc.)",NULL
+g_szErrEepromPolling:		db	"Timeout when polling EEPROM.",LF
+							db	"EEPROM was not flashed properly!",NULL
+g_szErrEepromVerify:		db	"EEPROM did not return the same byte that was written.",LF
+							db	"EEPROM was not flashed properly!",NULL
+g_szPCFlashSuccessful:		db	"EEPROM was written successfully.",LF
+							db	"Press any key to reboot.",NULL
+g_szForeignFlash:			db	"EEPROM was written successfully.",NULL
 
 
 ; Strings for main menu

--- a/XTIDE_Universal_BIOS_Configurator_v2/Src/Strings.asm
+++ b/XTIDE_Universal_BIOS_Configurator_v2/Src/Strings.asm
@@ -56,7 +56,7 @@ g_szFlashTitle:				db	"Flashing EEPROM, please wait.",NULL
 g_szErrEepromTooSmall:		db	"Image is too large for selected EEPROM type!",NULL
 g_szErrAddrNot32KAligned:	db	"The selected EEPROM type requires the address to be 32 "
 							db	"kiB aligned (C800, D000, D800, E000, etc.)",NULL
-g_szErrEepromDetection:		db	"EEPROM type not detected.",LF
+g_szErrEepromDetection:		db	"EEPROM of type not found.",LF
 							db	"EEPROM was not flashed properly!",NULL
 g_szErrEepromPolling:		db	"Timeout when polling EEPROM.",LF
 							db	"EEPROM was not flashed properly!",NULL

--- a/XTIDE_Universal_BIOS_Configurator_v2/Src/Strings.asm
+++ b/XTIDE_Universal_BIOS_Configurator_v2/Src/Strings.asm
@@ -54,8 +54,10 @@ g_szGenericDialogInfo:	db	"Press ENTER or ESC to close dialog.",NULL
 ; Flashing related strings
 g_szFlashTitle:				db	"Flashing EEPROM, please wait.",NULL
 g_szErrEepromTooSmall:		db	"Image is too large for selected EEPROM type!",NULL
-g_szErrAddrNot32KAligned:	db	"The selected EEPROM type requires the address be 32 "
+g_szErrAddrNot32KAligned:	db	"The selected EEPROM type requires the address to be 32 "
 							db	"kiB aligned (C800, D000, D800, E000, etc.)",NULL
+g_szErrEepromDetection:		db	"EEPROM type not detected.",LF
+							db	"EEPROM was not flashed properly!",NULL
 g_szErrEepromPolling:		db	"Timeout when polling EEPROM.",LF
 							db	"EEPROM was not flashed properly!",NULL
 g_szErrEepromVerify:		db	"EEPROM did not return the same byte that was written.",LF

--- a/XTIDE_Universal_BIOS_Configurator_v2/Src/Strings.asm
+++ b/XTIDE_Universal_BIOS_Configurator_v2/Src/Strings.asm
@@ -560,7 +560,7 @@ g_szMultichoiceEepromType:		db	"2816 (2 kiB)",LF
 								db	"2864 mod (8 kiB)",LF
 								db	"28256 (32 kiB)",LF
 								db	"28512 (64 kiB)",LF
-								db	"SST39SFxxx flash",NULL
+								db	"SST39SFx flash",NULL
 g_szValueFlash2816:				db	"2816",NULL
 g_szValueFlash2864:				db	"2864",NULL
 g_szValueFlash2864Mod:			db	"2864mod",NULL


### PR DESCRIPTION
First pass at adding SST39SF0x0 flash ROM programming support. Tested to be working on a 486 DX/2-66 and at Tandy 1000 HX.